### PR TITLE
Update the command error log to include more verbosity.

### DIFF
--- a/JHDBot/bot.py
+++ b/JHDBot/bot.py
@@ -147,7 +147,7 @@ async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
         await ctx.send('Invalid command. Please use `$help` to know list current valid commands.')
     else:
-        logger.warning("Invalid command detected resulting in error")
+        logger.info(f"Error parsing bot command in channel: <#{ctx.message.channel.id}>\n```\nAuthor: {ctx.message.author}\nMessage: {ctx.message.content}\n```")
         await ctx.send(
             f'An error occurred. Please use `{bot.command_prefix}reportbot <Error>`')
 


### PR DESCRIPTION
As of the now whenever the bot runs into an error parsing a command, the log just says that there is an error but not what caused the error. This patch will include the message content of the bot command that caused the error.